### PR TITLE
Clean up styles, add property `definitionsUrl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
 
+### `npm start-win`
+
+If you're developing in Windows / WSL, the watch in `npm start` sometimes doesn't work.
+Use this command instead and hopefully it works now.
+
 ### `npm test`
 
 Launches the test runner in the interactive watch mode.\

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://rpg.sandcat.nl/l5r2018/dictionary/",
   "scripts": {
     "start": "react-scripts start",
+    "start-win": "WATCHPACK_POLLING=true react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dictionary",
   "version": "0.2.0",
   "private": true,
-  "homepage": "https://rpg.sandcat.nl/l5r2018/dictionary/",
+  "homepage": "https://rpg.sandcat.nl/",
   "scripts": {
     "start": "react-scripts start",
     "start-win": "WATCHPACK_POLLING=true react-scripts start",

--- a/public/glossary.php/glossary.json
+++ b/public/glossary.php/glossary.json
@@ -1,0 +1,34 @@
+{
+    "definitions": [
+        {
+            "id": "test-term-1",
+            "term": "Test term 1",
+            "definition": "Mark*down* test"
+        },
+        {
+            "id": "test-term-2",
+            "term": "Test term 2",
+            "definition": "**another style**"
+        },
+        {
+            "id": "genpuku",
+            "term": "Genpuku",
+            "definition": "Coming of age [ceremony](https://en.wikipedia.org/wiki/Genpuku)"
+        },
+        {
+            "id": "rokugan",
+            "term": "Rokugan",
+            "definition": "The Emerald Empire"
+        },
+        {
+            "id": "crane-clan",
+            "term": "Crane Clan",
+            "definition": "The Crane Clan logo is ![Crane Clan Logo](http://homeofthecraneclan.com/wp-content/uploads/2016/08/Mon_Crane.gif), one of the great clans of [Rokugan](#rokugan)."
+        },
+        {
+            "glossary": "glossary",
+            "term": "Glossary",
+            "definition": "Testing whether this works."
+        }
+    ]
+}

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div id="root" data-param-definitions-url="glossary.php/glossary.json"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,6 +4,6 @@ import App from './App';
 it('renders without crashing', () => {
     const div = document.createElement('div');
     const root = createRoot(div);
-    root.render(<App />);
+    root.render(<App definitionsUrl='test' />);
     root.unmount();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,25 +10,30 @@ interface IAppState {
     definitions: Definition[];
 }
 
-class App extends React.Component<{}, IAppState> {
+interface IProps {
+    definitionsUrl?: string;
+}
+
+class App extends React.Component<IProps, IAppState> {
     private listRef: React.RefObject<HTMLDivElement>;
     private hashedRef: React.RefObject<HTMLDivElement>;
 
-    public constructor(props: {}) {
+    public constructor(props: IProps) {
         super(props);
-        
+
         this.state = { loading: true, definitions: [] };
         this.listRef = React.createRef<HTMLDivElement>();
         this.hashedRef = React.createRef<HTMLDivElement>();
 
         this.startFetchData();
     }
-    
+
     public startFetchData = () => {
-        fetch('dictionary.php/dictionary.json')
+        const url = this.props.definitionsUrl || 'dictionary.php/dictionary.json';
+        fetch(url)
             .then(this.onReceiveData);
     }
-    
+
     public onReceiveData = (response: Response) => {
         response.json().then(val => {
             const newDefinitions = (val.definitions as IDefinitionDTO[])
@@ -39,12 +44,12 @@ class App extends React.Component<{}, IAppState> {
             this.setState({ loading: false, definitions: newDefinitions });
         });
     }
-    
+
     public render() {
         if (this.state.loading) {
             return <div>Loading...</div>;
         }
-        
+
         return <DefinitionList definitions={this.state.definitions} listRef={this.listRef} hashedRef={this.hashedRef}/>;
     }
 
@@ -66,7 +71,7 @@ class App extends React.Component<{}, IAppState> {
                 .then((v) => {
                     if (this.hashedRef.current !== null) {
                         this.hashedRef.current.scrollIntoView();
-                    }            
+                    }
                 });
         }
     }

--- a/src/DefinitionList.scss
+++ b/src/DefinitionList.scss
@@ -8,7 +8,7 @@
   &_Content {
     margin-top: 0;
     overflow: auto;
-    padding: 12px;
+    padding: 0.75em;
     box-sizing: border-box;
 
     p {

--- a/src/DefinitionListHeader.scss
+++ b/src/DefinitionListHeader.scss
@@ -2,23 +2,26 @@
   position: sticky;
   top: 0;
   width: auto;
-  height: 30px;
-  padding: 0 20px;
-  line-height: 30px;
-  font-size: medium;
+  height: auto;
+  padding: 0 1em;
+  line-height: 2em;
   font-weight: bold;
   text-align: center;
   background-color: #9a2e00;
 
   a {
     color: #fff;
-    font-family: 'Kaushan Script', cursive;
+    font-family: var(--font-family__header--campaign, var(--font-family__header, "Almendra",  TimesNewRoman, Times New Roman, Times, Baskerville, Georgia, serif));
     text-decoration: none;
     font-size: large;
   }
 
   &_Item {
-    padding-right: 1em;
+    display:inline-block;
     font-variant: small-caps;
+
+    &:not(:first-of-type) {
+      margin-left: 1em;
+    }
   }
 }

--- a/src/DefinitionListItem.scss
+++ b/src/DefinitionListItem.scss
@@ -1,6 +1,9 @@
 .DefinitionListItem {
   .DefinitionListItem_Term {
     font-weight: bold;
+    /* make sure the sticky header doesn't (fully) overlap item headers when jumping to them */
+    padding-top: 4rem;
+    margin-top: -4rem;
   }
 
   .DefinitionListItem_Definition {

--- a/src/DefinitionListItem.scss
+++ b/src/DefinitionListItem.scss
@@ -9,5 +9,10 @@
   .DefinitionListItem_Definition {
     padding-left: 1em;
     padding-bottom: 1em;
+
+    img {
+      max-width: 100%;
+      max-height: 20rem;
+    }
   }
 }

--- a/src/DefinitionListItemHeader.scss
+++ b/src/DefinitionListItemHeader.scss
@@ -1,12 +1,12 @@
 .DefinitionListItemHeader {
   font-weight: bold;
-  padding-bottom: 10px;
-  font-size: 140%;
-  margin-top: 15px;
+  padding-bottom: 0.5em;
+  font-size: 1.4rem;
+  margin-top: 1em;
+  font-family: var(--font-family__header--campaign, var(--font-family__header, "Almendra",  TimesNewRoman, Times New Roman, Times, Baskerville, Georgia, serif));
+  text-decoration: none;
+  /* make sure the sticky header doesn't (fully) overlap item headers when jumping to them */
+  padding-top: 4rem;
+  margin-top: -4rem;
 
-  a {
-    font-family: 'Kaushan Script', cursive;
-    text-decoration: none;
-    font-size: large;
-  }
 }

--- a/src/DefinitionListItemHeader.tsx
+++ b/src/DefinitionListItemHeader.tsx
@@ -9,7 +9,7 @@ interface IProps {
 export class DefinitionListItemHeader extends React.Component<IProps> {
     public render() {
         return (
-            <div className="DefinitionListItemHeader"><a id={`header-${this.props.letter.toLowerCase()}`}>{this.props.letter}</a></div>
+            <div className="DefinitionListItemHeader" id={`header-${this.props.letter.toLowerCase()}`}>{this.props.letter}</div>
         )
     }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,0 @@
-body {
-  margin: 0;
-  padding: 0;
-  font-family: sans-serif;
-}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import './index.scss';
 import App from './App';
 
 const root = ReactDOM.createRoot(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,13 @@
-import * as ReactDOM from 'react-dom';
-import App from './App';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
 import './index.scss';
+import App from './App';
 
-ReactDOM.render(
-    <App />,
-    document.getElementById('root') as HTMLElement
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-);
+const rootElement: HTMLElement = document.getElementById('root') as HTMLElement;
+const root = ReactDOM.createRoot(rootElement);
+const definitionsUrl: string | undefined = rootElement.getAttribute('data-param-definitions-url')?.trim();
+
 root.render(
   <React.StrictMode>
-    <App />
+    <App definitionsUrl={definitionsUrl} />
   </React.StrictMode>
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "importHelpers": true,
     "strict": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
+    "allowSyntheticDefaultImports": true,
     "noUnusedLocals": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12200,11 +12200,11 @@ __metadata:
 
 "typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>":
   version: 4.9.4
-  resolution: "typescript@patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"
+  resolution: "typescript@patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=289587"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 1caaea6cb7f813e64345190fddc4e6c924d0b698ab81189b503763c4a18f7f5501c69362979d36e19c042d89d936443e768a78b0675690b35eb663d19e0eae71
+  checksum: 2160f7ad975c59b2f5816817d3916be1d156c5688a7517602b3b640c5015e740f4ba933996ac85371d68f7bbdd41602150fb8b68334122ac637fdb5418085e7a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- cleaned up the existing CSS to make it more consistent, use `rem` / `em` instead of `px`
- also adopted some CSS changes that Xav made on the live website that should be part of the App itself
- introduce CSS variables to make theming easier (`--font-family__header` and `--font-family__header--campaign`), maybe I'll introduce `--font-family__body` and `--font-family__body--campaign` later if needed)
- add property `definitionsUrl` so we can add the App on different pages. Example use:
  ```
  <div id="root" <div id="root" data-param-definitions-url="glossary.php/glossary.json">Loading...</div>l="glossary.php/glossary.json">Loading...</div>
  ```
  The value of `data-param-definitions-url`, if set, is automatically passed on to the App as `definitionsUrl`.
  If not set, the URL defaults to `dictionary.php/dictionary.json`.